### PR TITLE
Find apps observable

### DIFF
--- a/dci-2.0/src/app/autocomplete/autocomplete.component.ts
+++ b/dci-2.0/src/app/autocomplete/autocomplete.component.ts
@@ -50,7 +50,8 @@ export class AutocompleteComponent implements OnInit, OnChanges {
     if (this.query.trim() !== '') {
       let nonce = this.nonce = Math.round(1e12 * Math.random()).toString();
 
-      this.loader.findApps$({startsWith: this.query.trim(), fullInfo:true, onlyAnalyzed:true}).subscribe((data) => {
+      this.loader.findApps$({startsWith: this.query.trim(), fullInfo:true, onlyAnalyzed:true})
+      .subscribe((data) => {
         var results = data.json() as APIAppInfo[];
         console.log(results);
         if (nonce !== this.nonce) { return; }

--- a/dci-2.0/src/app/autocomplete/autocomplete.component.ts
+++ b/dci-2.0/src/app/autocomplete/autocomplete.component.ts
@@ -50,8 +50,9 @@ export class AutocompleteComponent implements OnInit, OnChanges {
     if (this.query.trim() !== '') {
       let nonce = this.nonce = Math.round(1e12 * Math.random()).toString();
 
-      this.loader.findApps(this.query.trim()).then((results: APIAppInfo[]) => {
-
+      this.loader.findApps$({startsWith: this.query.trim(), fullInfo:true, onlyAnalyzed:true}).subscribe((data) => {
+        var results = data.json() as APIAppInfo[];
+        console.log(results);
         if (nonce !== this.nonce) { return; }
 
         let qL = this.query.toLowerCase().trim(),

--- a/dci-2.0/src/app/compare/compare.component.html
+++ b/dci-2.0/src/app/compare/compare.component.html
@@ -15,6 +15,7 @@
                         <div class="summary">{{ appInfo(original_app?.target.appid)?.storeinfo.summary }}</div>
                         <div class="desc">{{ appInfo(original_app?.target.appid)?.storeinfo.description?.split(' ').slice(0,50).join(' ') }}</div>
                         <p></p>
+
                         <app-company-list [app]='original_app?.target.appid'></app-company-list>
                     </div>
                 </td>

--- a/dci-2.0/src/app/loader.service.ts
+++ b/dci-2.0/src/app/loader.service.ts
@@ -301,7 +301,7 @@ export class LoaderService {
       fullInfo?: boolean, 
       onlyAnalyzed?: boolean, 
       limit?: number
-    }) {
+    })/*:Observable<Response>*/{
     
     let body = this.parseFetchAppParams(options);    
     let appData: APIAppInfo[];

--- a/dci-2.0/src/app/loader.service.ts
+++ b/dci-2.0/src/app/loader.service.ts
@@ -250,6 +250,73 @@ export class LoaderService {
         return appinfos;
       })
   }
+  
+  /**
+   * Parses JSON Object into a URL param options object and then Turns that to a
+   * string. 
+   * @param options JSON of param options that can be used to query the xray API.
+   */
+  private parseFetchAppParams(options: {
+      title?: string,
+      startsWith?: string, 
+      appID?: string, 
+      fullInfo?: boolean, 
+      onlyAnalyzed?: boolean, 
+      limit?: number
+    }) :string {
+      // Initialising URL Parameters from passed in options.
+    let urlParams = new URLSearchParams();
+
+    if(options.title) {
+      urlParams.append('title', options.title);
+    }
+    if(options.startsWith) {
+      urlParams.append('startsWith', options.startsWith);
+    }
+    if(options.appID) {
+      urlParams.append('appID', options.appID);
+    }
+    if(options.fullInfo) {
+      urlParams.append('isFull',  options.fullInfo ? 'true': 'false');
+    }
+    if(options.onlyAnalyzed) {
+      urlParams.append('onlyAnalyzed', options.onlyAnalyzed ? 'true': 'false');
+    }
+    if(options.limit) {
+      urlParams.append('limit', options.limit.toString());
+    }
+    return urlParams.toString();
+  }
+
+  /**
+   * Issues a get request to the xray API using the param options provied as a
+   * json parameter. the JSON is passed to 'parseFetchAppParams' that acts as a 
+   * helper function to stringify the optins into a URL acceptable string.
+   * @param options JSON of param options that can be used to query the xray API.
+   */
+  findApps$(options: {
+      title?: string,
+      startsWith?: string, 
+      appID?: string, 
+      fullInfo?: boolean, 
+      onlyAnalyzed?: boolean, 
+      limit?: number
+    }) {
+    
+    let body = this.parseFetchAppParams(options);    
+    let appData: APIAppInfo[];
+
+    return this.http.get('http://localhost:8118/api/apps?' + body).do((data) => {
+      var res = data.json() as APIAppInfo[];
+      return data.json().map((app :APIAppInfo) => {
+        if (!app) {
+          throw new Error('null returned from endpoint ' + body);
+        } 
+        return this._prepareAppInfo(app);
+       }) as APIAppInfo[];
+    });
+  }
+  
 
   @memoize((appid: string): string => appid)
   getAlternatives(appid: string): Promise<APIAppInfo[]> {


### PR DESCRIPTION
Updated Autocomplete to make use of Observable `findApps$(...)`
```
this.loader.findApps$({startsWith: this.query.trim(), fullInfo:true, onlyAnalyzed:true})
      .subscribe((data) => {
```

Created an observable version of `findApps()`
```
findApps$(options: {
      title?: string,
      startsWith?: string, 
      appID?: string, 
      fullInfo?: boolean, 
      onlyAnalyzed?: boolean, 
      limit?: number
}) { ...
```
Made use of `URLSearchParams().toString();` To produce params for url.